### PR TITLE
Tests: add travis ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+services: mongodb
+python:
+  - "2.7"
+
+install:
+  - "pip install ."
+
+script: python -m unittest discover

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://travis-ci.org/ClearcodeHQ/migopy.svg?branch=master
+    :target: https://travis-ci.org/ClearcodeHQ/migopy
+
 Migopy 1.0 - Mongo Migrations for Python
 =====================================
 


### PR DESCRIPTION
Add simple travis config for tests on python2.7 and include CI master branch status in README
